### PR TITLE
Only push the latest tag to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,12 +33,7 @@ jobs:
         with:
           images: leachim2k/face-movie
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,format=short
+            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

Simplifies the Docker Hub tag strategy to a single tag: `latest`.

The previous configuration produced extra tags (`main`, `sha-<short>`,
plus the unused semver/PR variants). They cluttered the Hub UI without
adding value here — commit traceability is already in the OCI image
labels (`org.opencontainers.image.revision`, `image.source`,
`image.version`), readable via `docker inspect leachim2k/face-movie:latest`.

## After merge

The next push to `main` will push **only** `latest`. The existing
`main` and `sha-d670b8a` tags from previous runs remain on Docker Hub
until you remove them manually:

- https://hub.docker.com/r/leachim2k/face-movie/tags → for each unwanted
  tag, click the trash icon
- Or via API once you have a PAT: `curl -X DELETE -H "Authorization: JWT <token>"
  https://hub.docker.com/v2/repositories/leachim2k/face-movie/tags/<tagname>/`

## Test plan

- [ ] After merge, the docker-publish run pushes a single tag `latest`
- [ ] `docker pull leachim2k/face-movie:latest` resolves to a manifest
      list with `linux/amd64` + `linux/arm64`
