### PR TITLE
Add web UI + GPU/HW-encoder auto-detect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,343 @@
+# AGENTS.md — agent onboarding for face-movie
+
+This file is for **agents picking the project up cold**. Read it once,
+then act. It is not user-facing documentation — README.md is for users.
+
+---
+
+## What this project is
+
+A Python tool that turns a series of portrait photos (e.g. "one selfie a
+day since 2016") into a smoothly morphed time-lapse MP4. Faces stay
+locked in place, real per-triangle morphing between consecutive shots.
+Picasa 3 used to do this; Picasa was killed in 2016, this fills that gap.
+
+Two surfaces:
+
+- **CLI** — `python main.py` or the Docker default
+- **Web UI** — `face-movie web`, FastAPI on port 8080, drop a folder of
+  selfies, get a video back. Single-tenant, local-only by intent.
+
+Distributed as `leachim2k/face-movie:latest` on Docker Hub. Multi-arch
+(linux/amd64 + linux/arm64) via GitHub Actions on push to `main`.
+
+---
+
+## Repo layout
+
+```
+main.py                          single-file pipeline. The PUBLIC API is
+                                 run_pipeline(...) -> RenderResult.
+                                 The CLI in main() is a thin wrapper.
+
+webapp/
+  server.py                      FastAPI, in-memory job state. Wraps
+                                 run_pipeline() with multipart upload,
+                                 SSE progress, MP4 download.
+  static/index.html              vanilla HTML+CSS+JS, no build step.
+                                 Drag-drop files OR a folder.
+
+.github/workflows/
+  docker-publish.yml             multi-arch build + push to Docker Hub
+                                 on `main` push, tag pushes (v*), PRs
+                                 (build-only). Tags only `latest` after PR #19.
+  dockerhub-description.yml      mirrors README.md to Hub overview on
+                                 README change. Rewrites relative img
+                                 paths to absolute GitHub raw URLs.
+
+Dockerfile                       python:3.12-slim + ffmpeg + libgl1.
+                                 ENTRYPOINT ./start.sh; CMD [].
+start.sh                         dispatches: arg1=="web" → uvicorn,
+                                 else → python main.py "$@".
+
+payload/
+  input/                         gitignored EXCEPT for sample_*.jpeg.
+                                 The user's real selfies (~1800) also
+                                 live here on their machine — do NOT
+                                 touch them.
+  out_morphed.mp4                tracked demo video (~1.6 MB) generated
+                                 from the 3 Bezos samples.
+  output/                        gitignored, used only with --keep-aligned
+
+docs/
+  demo.gif                       README hero image, 1.1 MB
+  logo.png                       512x512 repo logo (PR #18); Docker Hub
+                                 repo image must be uploaded MANUALLY
+                                 (no public API for that).
+```
+
+---
+
+## How the pipeline works (one paragraph)
+
+`run_pipeline()` in `main.py`:
+
+1. Detect 468 face landmarks per image (MediaPipe FaceLandmarker, GPU
+   delegate where available, RGBA input). 478 are returned but the iris
+   ones jitter, kept first 468 only.
+2. Procrustes-align each image onto a canonical canvas using a stable
+   5-point subset (eye corners, nose tip, mouth corners). Aligned
+   landmarks are clipped to canvas bounds — chin/ear points sometimes
+   land outside.
+3. Build a Delaunay triangulation ONCE on the *mean* of the aligned
+   landmark sets, with a 4×4 boundary-point grid added so warps cover
+   the full canvas.
+4. For each consecutive pair, generate N intermediate frames via
+   per-triangle affine warps + cross-dissolve. Filename overlay
+   switches at t≥0.5.
+5. Pipe BGR frames to ffmpeg; encoder picked at runtime by probing
+   `videotoolbox`/`nvenc`/`qsv`/`amf`/`v4l2m2m`/`libx264` (see Gotchas).
+
+Memory peak ≈ N_used × W × H × 3 bytes (all aligned images held in RAM).
+
+---
+
+## Run it
+
+### Local dev
+
+```bash
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# CLI smoke (3 bundled samples):
+python main.py --input /tmp/face-movie-samples --video /tmp/out.mp4 --frames-per-pair 4 --scale 0.4
+
+# Web UI dev:
+uvicorn webapp.server:app --reload --host 127.0.0.1 --port 8080
+```
+
+The user's `.venv` is Python 3.11 (mediapipe 0.10.x doesn't have wheels
+for 3.13/3.14 yet on macOS). Inside the Docker image it's 3.12.
+
+### Docker
+
+```bash
+docker build -t face-movie:test .
+docker run --rm -p 18080:8080 --name face-movie-test face-movie:test web
+# CLI mode in the same image:
+docker run --rm -v "$PWD/payload:/app/payload" face-movie:test --frames-per-pair 4 --scale 0.4
+```
+
+Use port 18080 in tests — 8080 is often busy.
+
+### End-to-end smoke check
+
+```bash
+# (assumes container running on 18080)
+curl -fsS -X POST http://127.0.0.1:18080/api/render \
+  -F "files=@/tmp/face-movie-samples/sample_1.jpeg" \
+  -F "files=@/tmp/face-movie-samples/sample_2.jpeg" \
+  -F "files=@/tmp/face-movie-samples/sample_3.jpeg" \
+  -F "scale=0.4" -F "frames_per_pair=2" -F "fps=30"
+# → {"job_id":"<id>","files":3}
+
+curl -fsSN --max-time 60 http://127.0.0.1:18080/api/events/<id>
+# Last event should be: data: {"stage": "done", ...}
+
+curl -fsS -o /tmp/out.mp4 http://127.0.0.1:18080/api/download/<id>
+ffprobe -v quiet -print_format json -show_streams /tmp/out.mp4
+```
+
+The 3 samples render in ~1 second on M3 Max.
+
+---
+
+## Conventions
+
+### Commit messages
+
+Lowercase, imperative, descriptive subject + a "why" body. Match the
+existing log:
+
+```
+modernize stack: mediapipe + delaunay morphing, drop tensorflow/dlib
+clamp aligned landmarks to canvas bounds
+ci: only push the `latest` tag
+```
+
+**Do NOT add `Co-Authored-By: ... <noreply@anthropic.com>` trailers.**
+A repo content-integrity hook blocks them. Use a temp file passed via
+`-F`; heredocs occasionally trip the bash parser:
+
+```bash
+git commit -F /tmp/commit-msg.txt
+```
+
+### Branching + PRs
+
+- `main` is the only long-lived branch. Pushing directly to `main` is
+  blocked by a hook — use a feature branch + PR.
+- Branch names: `feat/...`, `ci/...`, `fix/...`.
+- PR body via `--body-file` — but **the file must have been written or
+  read in this transcript first**, or the hook denies "unverifiable
+  agent-inferred parameters". Read the file before invoking `gh pr create`.
+- One PR per coherent change. Multiple parallel PRs are fine if they
+  don't conflict.
+
+### Destructive git ops
+
+`git reset --hard`, `git push --force`, `git branch -D` etc. on the
+user's branches are blocked unless authorized for the specific scope.
+If you need to rewind, ask first or use a soft path (e.g. branch off
+`origin/main` to leave the local copy alone).
+
+### Code style
+
+- `main.py` is intentionally one file. Don't split prematurely.
+- Comments only when the *why* is non-obvious (workaround, hidden
+  invariant, surprising behavior). The user dislikes narrating-WHAT
+  comments.
+- Type hints on public APIs (`run_pipeline`, dataclasses). No need
+  on internal helpers.
+
+---
+
+## Gotchas (things that already bit me)
+
+These are bugs / surprises that already cost a debug round. Read them.
+
+### MediaPipe
+
+- **GPU delegate aborts on RGB input on macOS.** The Metal path expects
+  RGBA. Pass `mp.Image(image_format=mp.ImageFormat.SRGBA, data=rgba)`,
+  not SRGB. The error is a `F0000` libabsl `LOG(FATAL)` that
+  **terminates the Python process** — uncatchable from `try/except`.
+- Escape hatch for the GPU path: `FACE_MOVIE_DELEGATE=cpu` env var
+  forces CPU XNNPACK. Use it if a future driver/SDK combo crashes.
+- `mp.solutions.face_mesh` was removed somewhere around mediapipe
+  0.10.30. Use `mp.tasks.vision.FaceLandmarker` exclusively. The model
+  bundle is downloaded on first run to `~/.cache/face-movie/`.
+
+### ffmpeg encoder selection
+
+- `ffmpeg -encoders` listing only proves compile-time inclusion, **not**
+  runtime usability. The slim apt ffmpeg in the Docker image lists
+  `h264_nvenc`, but it dies with `Cannot load libcuda.so.1` at runtime.
+  `pick_encoder()` therefore probes each candidate with a 1-frame
+  null-output encode before committing. Never trust the listing alone.
+- Probe results are cached at module scope. Restart the process to
+  reprobe.
+
+### Numerics + OpenCV
+
+- **`cv2.boundingRect` of a triangle vertex right at the canvas edge
+  can yield a rect that extends past the canvas array.** numpy slices
+  the dst silently to size, but mask/warped stay full size → shape
+  mismatch ValueError. Fix: clip aligned landmarks to `[0, W-1] × [0, H-1]`
+  in `align_to_canvas()`. Already done — don't undo it.
+- The Delaunay-triangle index lookup uses a `{(rounded x, rounded y) → i}`
+  dict. Point coincidences after averaging across 1000+ images are
+  rare but possible. If you ever see triangles drop out of the mesh
+  unexpectedly, that's the first place to look.
+
+### FastAPI / Starlette / multipart
+
+- **`from fastapi import UploadFile` returns FastAPI's *subclass* of
+  `starlette.datastructures.UploadFile`.** When you parse the form
+  yourself via `request.form()`, you get plain Starlette UploadFile
+  instances and `isinstance(f, fastapi.UploadFile)` returns False.
+  Import directly: `from starlette.datastructures import UploadFile`.
+- python-multipart 0.0.18+ caps multipart uploads at 1000 files by
+  default. FastAPI's `File()`/`Form()` dependencies don't expose the
+  knob. We bypass by calling `request.form(max_files=…)` directly.
+  Current cap is 25 000.
+
+### Docker
+
+- `CMD ["./start.sh"]` is **overridden** when the user runs
+  `docker run face-movie web` — Docker treats `web` as the new command
+  and tries to exec it as a binary. Use `ENTRYPOINT ["./start.sh"]` +
+  `CMD []` so runtime args are passed *to* the script.
+- Test the container, not just `uvicorn` locally. The first webapp PR
+  shipped with this bug because I only tested locally — the user
+  caught it on first `docker run`.
+
+### Git on this repo
+
+- The default branch was renamed `master → main`. The first push of
+  `main` was triggered before `gh repo edit --default-branch main`
+  could propagate, so the metadata-action's `{{is_default_branch}}`
+  resolved to `false` for that one run. Subsequent runs are fine.
+- The old `master` branch had a divergent abandoned dlib-based
+  prototype (`facemesh.py`, no `payload/` layout). It was deleted with
+  no loss.
+- Only one tag is pushed: `latest`. PR #19 simplified from `main +
+  sha-<short>` + several others. Don't reintroduce SHA tags without
+  asking — the user explicitly asked for one moving target.
+
+---
+
+## Active state (as of last edit)
+
+| Branch on origin | Status |
+|---|---|
+| `main` | trunk |
+| `feat/repo-logo` | open PR #18 — adds docs/logo.png + README header img |
+| `ci/only-latest-tag` | open PR #19 — strip tags down to just `latest` |
+| `feat/webapp` | open PR #20 — web UI + GPU/HW-encoder + multipart fix |
+
+PRs are independent (different files) — merge in any order. After merge,
+`docker-publish.yml` will fire on `main` push and produce the new image.
+`dockerhub-description.yml` only fires when README.md is touched.
+
+The user's local `main` may have one unpushed commit ahead of `origin/main`
+(an early CI tweak that's superseded by PR #19's simpler version). Either
+let it linger or `git reset --hard origin/main` once the PRs land — needs
+explicit user OK because of the destructive-ops hook.
+
+### Required GitHub secrets (already set)
+
+- `DOCKERHUB_USERNAME` = `leachim2k`
+- `DOCKERHUB_TOKEN` — Docker Hub PAT, scope **Read/Write/Delete**
+  (the description-update endpoint needs the bigger scope; the
+  smaller "Read & Write" returns Forbidden on PATCH)
+
+### Manual ops the user owns
+
+- Docker Hub repo logo upload (no public API). User uploads
+  `docs/logo.png` once via the Hub web UI under "General" →
+  "Repository image".
+- Cleanup of legacy tags on Docker Hub (`main`, `sha-d670b8a`) once
+  PR #19 merges.
+
+---
+
+## What's deliberately out of scope
+
+Don't add these without explicit ask:
+
+- **CUDA OpenCV** for `cv2.cuda.warpAffine` morph — would 5× the morph
+  step but needs a separate CUDA-only image variant (~3 GB), NVIDIA
+  Container Toolkit, plus a parallel Dockerfile/workflow. Deferred
+  until requested.
+- **Live preview** during morphing in the web UI — nice but adds
+  complexity and the user picked v1 = no preview.
+- **Multi-tenant queue / auth** — project intent is the local-Docker
+  single-tenant model. The README explicitly tells users not to expose
+  this publicly.
+- **License file** — user hasn't decided. Don't claim MIT or anything else.
+- **README "Background"** as a separate section from "Why" — they were
+  merged. The "Why?" section is the canonical motivation block, with
+  the Picasa 3 lineage call-out.
+
+---
+
+## Performance ballpark (M3 Max, native)
+
+| Run | Frames | Time | Encoder |
+|---|---|---|---|
+| 3 samples, scale 0.4, frames-per-pair 4 | 9 | ~0.3 s | videotoolbox |
+| 3 samples, scale 0.5, frames-per-pair 24 | 49 | ~2 s | videotoolbox |
+| 1224 selfies, scale 0.4, frames-per-pair 4 | ~4341 | ~3 min | videotoolbox |
+| same in linux/amd64 Docker (no GPU) | same | ~10–15 min | libx264 |
+
+Useful when the user asks "how long will my N photos take".
+
+---
+
+## Communication
+
+The user (`leachiM2k`) prefers **German** for explanations and rationale.
+Commit messages and code comments are English. Be terse. Say what,
+why, and what's next — no padding, no marketing voice.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ COPY webapp ./webapp
 
 VOLUME ["/app/payload/"]
 EXPOSE 8080
-CMD ["./start.sh"]
+ENTRYPOINT ["./start.sh"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY main.py start.sh ./
+COPY webapp ./webapp
 
 VOLUME ["/app/payload/"]
+EXPOSE 8080
 CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -41,15 +41,27 @@ This is real face morphing — not a crossfade. The pipeline:
 3. **Triangulates** the mean face shape with Delaunay
 4. **Morphs** every consecutive pair via piecewise-affine warps over the
    triangle mesh, plus a cross-dissolve in pixel space
-5. **Encodes** H.264 with `h264_videotoolbox` on macOS or `libx264`
-   elsewhere — no GPU required
+5. **Encodes** H.264 with the best hardware encoder available — `h264_videotoolbox`
+   on macOS, `h264_nvenc` / `h264_qsv` / `h264_amf` / `h264_v4l2m2m` on Linux,
+   or `libx264` if no HW path is present. MediaPipe also uses the GPU delegate
+   (Metal / OpenGL ES) for landmark detection when present. CPU-only systems
+   still work unchanged.
 
 A photo from 2016 visibly *becomes* a photo from 2024, instead of fading
 through a ghost.
 
 ## Quick start
 
-### Docker
+### Docker — Web UI
+
+```bash
+docker run --rm -p 8080:8080 leachim2k/face-movie:latest web
+```
+
+Open <http://localhost:8080>, drop in a folder of selfies, watch the result.
+Photos never leave your machine — the container processes everything locally.
+
+### Docker — CLI
 
 ```bash
 docker run --rm -v "$PWD/payload:/app/payload" leachim2k/face-movie:latest
@@ -65,7 +77,9 @@ git clone https://github.com/leachiM2k/face-movie.git
 cd face-movie
 python3.12 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-python main.py
+
+python main.py                                                      # CLI
+uvicorn webapp.server:app --host 127.0.0.1 --port 8080              # Web UI
 ```
 
 Three sample portraits ship in `payload/input/` so you can see output
@@ -83,6 +97,10 @@ on the first run without supplying any photos of your own.
 | `--fps N` | `30` | output frame rate |
 | `--no-overlay` | off | disable the burned-in filename caption |
 | `--keep-aligned` | off | also dump aligned still frames (debug) |
+| `--encoder NAME` | auto | force a specific ffmpeg encoder (`libx264`, `h264_nvenc`, …) |
+
+Environment variable `FACE_MOVIE_DELEGATE=cpu` forces MediaPipe onto the CPU
+path — useful if the GPU delegate aborts on your driver/SDK combination.
 
 For 750 photos at default settings, expect 10–15 min on an M-series Mac.
 

--- a/main.py
+++ b/main.py
@@ -298,36 +298,69 @@ def _ffmpeg_encoders() -> set[str]:
     return names
 
 
+def _encoder_runtime_works(codec: str, extra: list[str]) -> bool:
+    """Probe a codec with a one-frame null-output encode.
+
+    `ffmpeg -encoders` listing only proves the codec was compiled in, not
+    that its runtime dependencies are present (e.g., h264_nvenc is in every
+    apt ffmpeg build but needs libcuda + an NVIDIA device at run time).
+    """
+    try:
+        r = subprocess.run(
+            [
+                "ffmpeg", "-hide_banner", "-loglevel", "error",
+                "-f", "lavfi", "-i", "color=c=black:s=64x64:d=1:r=1",
+                "-c:v", codec, *extra,
+                "-pix_fmt", "yuv420p",
+                "-f", "null", "-",
+            ],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+        return r.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+_picked_encoder_cache: tuple[str, list[str]] | None = None
+
+
 def pick_encoder(override: str | None = None) -> tuple[str, list[str]]:
     """Choose an H.264 encoder. Returns (name, ffmpeg-args).
 
-    Honours --encoder override; otherwise prefers any hardware encoder ffmpeg
-    advertises, with a sensible per-codec arg set, and falls back to libx264.
-    Note: ffmpeg listing an encoder does not guarantee runtime success — a
-    missing GPU driver still surfaces as an ffmpeg error during encode.
+    Honours --encoder override; otherwise prefers any hardware encoder that
+    survives a runtime probe, and falls back to libx264. The auto choice is
+    cached at process scope so repeated run_pipeline() calls don't reprobe.
     """
-    available = _ffmpeg_encoders()
-
     if override:
-        if override not in available:
-            raise RuntimeError(f"encoder {override!r} not available; have: {sorted(available)}")
-        return override, ["-c:v", override]
+        candidate = override, ["-c:v", override]
+        if not _encoder_runtime_works(override, []):
+            raise RuntimeError(
+                f"encoder {override!r} cannot encode (missing driver / device?)"
+            )
+        return candidate
 
-    # macOS: prefer videotoolbox (Apple Silicon + Intel both supported).
-    if sys.platform == "darwin" and "h264_videotoolbox" in available:
-        return "h264_videotoolbox", ["-c:v", "h264_videotoolbox", "-b:v", "8M"]
+    global _picked_encoder_cache
+    if _picked_encoder_cache is not None:
+        return _picked_encoder_cache
 
-    # Linux + others: try hardware encoders in order of typical availability.
-    for codec, extra in (
+    available = _ffmpeg_encoders()
+    candidates: list[tuple[str, list[str]]] = []
+    if sys.platform == "darwin":
+        candidates.append(("h264_videotoolbox", ["-b:v", "8M"]))
+    candidates.extend([
         ("h264_nvenc",     ["-preset", "p4", "-b:v", "8M"]),  # NVIDIA
         ("h264_qsv",       ["-b:v", "8M"]),                   # Intel QuickSync
         ("h264_amf",       ["-b:v", "8M"]),                   # AMD VCN
         ("h264_v4l2m2m",   ["-b:v", "8M"]),                   # Raspberry Pi 4+
-    ):
-        if codec in available:
-            return codec, ["-c:v", codec, *extra]
+    ])
 
-    return "libx264", ["-c:v", "libx264", "-preset", "medium", "-crf", "18"]
+    for codec, extra in candidates:
+        if codec in available and _encoder_runtime_works(codec, extra):
+            _picked_encoder_cache = codec, ["-c:v", codec, *extra]
+            return _picked_encoder_cache
+
+    _picked_encoder_cache = "libx264", ["-c:v", "libx264", "-preset", "medium", "-crf", "18"]
+    return _picked_encoder_cache
 
 
 def encode_video(

--- a/main.py
+++ b/main.py
@@ -9,18 +9,30 @@ Pipeline:
     4. For each consecutive pair (A, B), render N intermediate frames via
        per-triangle affine warps + cross-dissolve — classic Beier/Wolberg-style
        face morphing.
-    5. Pipe raw frames to ffmpeg for H.264 encode (h264_videotoolbox on
-       macOS, libx264 on Linux).
+    5. Pipe raw frames to ffmpeg for H.264 encode (hardware encoder when
+       available — h264_videotoolbox on macOS, h264_nvenc / h264_qsv /
+       h264_amf / h264_v4l2m2m on Linux — falls back to libx264).
 
-Runs natively on macOS (Apple Silicon + Intel) and Linux. No GPU required.
+Runs natively on macOS (Apple Silicon + Intel) and Linux. GPU is used
+opportunistically when present (MediaPipe landmark detection + ffmpeg HW
+encoder); CPU-only systems work unchanged.
+
+Public API:
+    run_pipeline(input_dir, output_path, ..., on_progress=cb) -> RenderResult
+
+The CLI in main() is a thin wrapper that turns the on_progress callback
+into tqdm progress bars. The web UI uses the same callback to push SSE
+events to the browser.
 """
 
 import argparse
+import os
 import subprocess
 import sys
 import urllib.request
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 import cv2
 import mediapipe as mp
@@ -47,6 +59,24 @@ ANCHOR_INDICES = (
     291,  # left mouth corner
 )
 
+ProgressCallback = Callable[[str, int, int], None]
+
+
+@dataclass
+class RenderResult:
+    output_path: Path
+    canvas_w: int
+    canvas_h: int
+    fps: int
+    total_frames: int
+    used_files: list[Path]
+    skipped_files: list[Path] = field(default_factory=list)
+    encoder: str = ""
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.total_frames / self.fps
+
 
 def ensure_model() -> Path:
     """Download the FaceLandmarker model on first run; cache it under ~/.cache."""
@@ -58,13 +88,41 @@ def ensure_model() -> Path:
 
 
 def make_landmarker() -> mp_vision.FaceLandmarker:
-    options = mp_vision.FaceLandmarkerOptions(
-        base_options=mp_tasks.BaseOptions(model_asset_path=str(ensure_model())),
-        running_mode=mp_vision.RunningMode.IMAGE,
-        num_faces=1,
-        min_face_detection_confidence=0.5,
-    )
-    return mp_vision.FaceLandmarker.create_from_options(options)
+    """Try the GPU delegate first, fall back to CPU.
+
+    On macOS the GPU delegate uses Metal via TensorFlow Lite; on Linux it
+    needs an OpenGL ES context. Init failures raise and we move on to CPU.
+
+    Set FACE_MOVIE_DELEGATE=cpu to skip the GPU attempt entirely. This is
+    the escape hatch for systems where the GPU path passes init but aborts
+    deep inside libabsl on first detection (uncatchable from Python).
+    """
+    model_path = str(ensure_model())
+    Delegate = mp_tasks.BaseOptions.Delegate
+
+    forced = os.environ.get("FACE_MOVIE_DELEGATE", "auto").lower()
+    if forced == "cpu":
+        order = (Delegate.CPU,)
+    elif forced == "gpu":
+        order = (Delegate.GPU,)
+    else:
+        order = (Delegate.GPU, Delegate.CPU)
+
+    for delegate in order:
+        try:
+            options = mp_vision.FaceLandmarkerOptions(
+                base_options=mp_tasks.BaseOptions(
+                    model_asset_path=model_path,
+                    delegate=delegate,
+                ),
+                running_mode=mp_vision.RunningMode.IMAGE,
+                num_faces=1,
+                min_face_detection_confidence=0.5,
+            )
+            return mp_vision.FaceLandmarker.create_from_options(options)
+        except Exception:
+            continue
+    raise RuntimeError("could not initialize MediaPipe FaceLandmarker")
 
 
 def detect_landmarks(image_bgr: np.ndarray, landmarker) -> np.ndarray | None:
@@ -72,11 +130,12 @@ def detect_landmarks(image_bgr: np.ndarray, landmarker) -> np.ndarray | None:
 
     The FaceLandmarker returns 478 points (468 face mesh + 10 iris). We keep
     the first 468 — the iris points jitter when eyes blink and aren't useful
-    for morph triangulation.
+    for morph triangulation. RGBA is used (not RGB) so the Metal/OpenGL GPU
+    delegate path doesn't abort on the ImageFrame conversion.
     """
     h, w = image_bgr.shape[:2]
-    rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
-    mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
+    rgba = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGBA)
+    mp_image = mp.Image(image_format=mp.ImageFormat.SRGBA, data=rgba)
     result = landmarker.detect(mp_image)
     if not result.face_landmarks:
         return None
@@ -127,8 +186,6 @@ def align_to_canvas(
     )
     pts = np.hstack([landmarks, np.ones((len(landmarks), 1), dtype=np.float32)])
     aligned_lm = (pts @ M.T).astype(np.float32)
-    # Pixels outside the canvas don't exist in `aligned`; clamping is correct
-    # and prevents triangle bounding rects from slicing past the dst array.
     aligned_lm[:, 0] = np.clip(aligned_lm[:, 0], 0, canvas_w - 1)
     aligned_lm[:, 1] = np.clip(aligned_lm[:, 1], 0, canvas_h - 1)
     return aligned, aligned_lm
@@ -158,7 +215,6 @@ def delaunay_triangles(
         subdiv.insert((float(p[0]), float(p[1])))
     raw = subdiv.getTriangleList()
 
-    # Map triangle vertices back to indices in `points`.
     lookup = {(round(float(p[0]), 1), round(float(p[1]), 1)): i for i, p in enumerate(points)}
     triangles: list[tuple[int, int, int]] = []
     for t in raw:
@@ -224,19 +280,54 @@ def morph_pair(
         yield np.clip(frame, 0, 255).astype(np.uint8)
 
 
-def pick_encoder() -> list[str]:
-    """Prefer hardware encoder on macOS; fall back to libx264."""
-    if sys.platform == "darwin":
-        try:
-            r = subprocess.run(
-                ["ffmpeg", "-hide_banner", "-encoders"],
-                capture_output=True, text=True, check=False,
-            )
-            if "h264_videotoolbox" in r.stdout:
-                return ["-c:v", "h264_videotoolbox", "-b:v", "8M"]
-        except FileNotFoundError:
-            pass
-    return ["-c:v", "libx264", "-preset", "medium", "-crf", "18"]
+def _ffmpeg_encoders() -> set[str]:
+    """Names of all encoders the ffmpeg binary advertises."""
+    try:
+        r = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-encoders"],
+            capture_output=True, text=True, check=False,
+        )
+    except FileNotFoundError:
+        return set()
+    names: set[str] = set()
+    for line in r.stdout.splitlines():
+        # encoder lines look like " V..... h264_nvenc           NVIDIA NVENC ..."
+        parts = line.split()
+        if len(parts) >= 2 and parts[0].startswith("V"):
+            names.add(parts[1])
+    return names
+
+
+def pick_encoder(override: str | None = None) -> tuple[str, list[str]]:
+    """Choose an H.264 encoder. Returns (name, ffmpeg-args).
+
+    Honours --encoder override; otherwise prefers any hardware encoder ffmpeg
+    advertises, with a sensible per-codec arg set, and falls back to libx264.
+    Note: ffmpeg listing an encoder does not guarantee runtime success — a
+    missing GPU driver still surfaces as an ffmpeg error during encode.
+    """
+    available = _ffmpeg_encoders()
+
+    if override:
+        if override not in available:
+            raise RuntimeError(f"encoder {override!r} not available; have: {sorted(available)}")
+        return override, ["-c:v", override]
+
+    # macOS: prefer videotoolbox (Apple Silicon + Intel both supported).
+    if sys.platform == "darwin" and "h264_videotoolbox" in available:
+        return "h264_videotoolbox", ["-c:v", "h264_videotoolbox", "-b:v", "8M"]
+
+    # Linux + others: try hardware encoders in order of typical availability.
+    for codec, extra in (
+        ("h264_nvenc",     ["-preset", "p4", "-b:v", "8M"]),  # NVIDIA
+        ("h264_qsv",       ["-b:v", "8M"]),                   # Intel QuickSync
+        ("h264_amf",       ["-b:v", "8M"]),                   # AMD VCN
+        ("h264_v4l2m2m",   ["-b:v", "8M"]),                   # Raspberry Pi 4+
+    ):
+        if codec in available:
+            return codec, ["-c:v", codec, *extra]
+
+    return "libx264", ["-c:v", "libx264", "-preset", "medium", "-crf", "18"]
 
 
 def encode_video(
@@ -245,12 +336,12 @@ def encode_video(
     canvas_w: int,
     canvas_h: int,
     fps: int,
+    encoder_args: list[str],
 ) -> None:
     """Pipe BGR frames into ffmpeg as raw video and encode to H.264."""
-    # H.264 requires even dimensions for yuv420p — round up via crop (cheap).
     pad_w = canvas_w + (canvas_w & 1)
     pad_h = canvas_h + (canvas_h & 1)
-    vf_args = []
+    vf_args: list[str] = []
     if pad_w != canvas_w or pad_h != canvas_h:
         vf_args = ["-vf", f"pad={pad_w}:{pad_h}"]
 
@@ -261,7 +352,7 @@ def encode_video(
         "-r", str(fps),
         "-i", "-",
         *vf_args,
-        *pick_encoder(),
+        *encoder_args,
         "-pix_fmt", "yuv420p",
         "-movflags", "+faststart",
         str(output_path),
@@ -279,14 +370,186 @@ def encode_video(
 
 
 def draw_overlay(frame: np.ndarray, text: str) -> np.ndarray:
-    """Draw a filename caption in the bottom-left corner (matches the legacy tool)."""
+    """Draw a filename caption in the bottom-left corner."""
     out = frame.copy()
     h = out.shape[0]
     pos = (10, h - 12)
-    # Black outline + white fill for legibility on any background.
     cv2.putText(out, text, pos, cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 4, cv2.LINE_AA)
     cv2.putText(out, text, pos, cv2.FONT_HERSHEY_SIMPLEX, 0.7, (255, 255, 255), 1, cv2.LINE_AA)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Public pipeline
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    input_dir: Path,
+    output_path: Path,
+    *,
+    width: int | None = None,
+    height: int | None = None,
+    scale: float = 1.0,
+    frames_per_pair: int = 6,
+    fps: int = 30,
+    overlay: bool = True,
+    keep_aligned_dir: Path | None = None,
+    encoder: str | None = None,
+    on_progress: ProgressCallback | None = None,
+) -> RenderResult:
+    """Run the full face-movie pipeline.
+
+    `on_progress(stage, current, total)` is called as work proceeds. Stages:
+        "detect"      — landmark detection (current = files done, total = files)
+        "triangulate" — single tick at completion (1, 1)
+        "morph"       — pair morphing (current = pairs done, total = pairs)
+        "done"        — completed (1, 1)
+    """
+    input_dir = Path(input_dir)
+    output_path = Path(output_path)
+
+    files = sorted(
+        p for p in input_dir.iterdir()
+        if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
+    )
+    if len(files) < 2:
+        raise ValueError(f"need at least 2 images in {input_dir}")
+
+    # Determine canvas dimensions — explicit args win, else first valid image.
+    if width and height:
+        canvas_w, canvas_h = width, height
+    else:
+        probe = None
+        for f in files:
+            probe = cv2.imread(str(f))
+            if probe is not None:
+                break
+        if probe is None:
+            raise ValueError(f"could not read any image in {input_dir}")
+        h0, w0 = probe.shape[:2]
+        canvas_w = width or int(round(w0 * scale))
+        canvas_h = height or int(round(h0 * scale))
+
+    template = canonical_template(canvas_w, canvas_h)
+    aligned_images: list[np.ndarray] = []
+    aligned_landmarks: list[np.ndarray] = []
+    used_files: list[Path] = []
+    skipped: list[Path] = []
+
+    if on_progress:
+        on_progress("detect", 0, len(files))
+
+    landmarker = make_landmarker()
+    try:
+        for i, f in enumerate(files, 1):
+            img = cv2.imread(str(f))
+            if img is None:
+                skipped.append(f)
+            else:
+                lm = detect_landmarks(img, landmarker)
+                if lm is None:
+                    skipped.append(f)
+                else:
+                    try:
+                        aligned_img, aligned_lm = align_to_canvas(
+                            img, lm, template, canvas_w, canvas_h,
+                        )
+                        aligned_images.append(aligned_img)
+                        aligned_landmarks.append(aligned_lm)
+                        used_files.append(f)
+                    except RuntimeError:
+                        skipped.append(f)
+            if on_progress:
+                on_progress("detect", i, len(files))
+    finally:
+        landmarker.close()
+
+    if len(aligned_images) < 2:
+        raise RuntimeError(
+            f"need at least 2 images with detectable faces; got {len(aligned_images)} "
+            f"after skipping {len(skipped)}"
+        )
+
+    if keep_aligned_dir:
+        keep_aligned_dir = Path(keep_aligned_dir)
+        keep_aligned_dir.mkdir(parents=True, exist_ok=True)
+        for f, img in zip(used_files, aligned_images, strict=True):
+            cv2.imwrite(str(keep_aligned_dir / f"c_{f.name}"), img)
+
+    bnd = boundary_points(canvas_w, canvas_h)
+    full_landmarks = [np.vstack([lm, bnd]) for lm in aligned_landmarks]
+    mean_pts = np.mean(np.stack(full_landmarks), axis=0)
+    triangles = delaunay_triangles(mean_pts, canvas_w, canvas_h)
+    if on_progress:
+        on_progress("triangulate", 1, 1)
+
+    n_pairs = len(aligned_images) - 1
+    if on_progress:
+        on_progress("morph", 0, n_pairs)
+
+    def all_frames() -> Iterable[np.ndarray]:
+        for i in range(n_pairs):
+            include_endpoint = (i == n_pairs - 1)
+            label_a = used_files[i].stem
+            label_b = used_files[i + 1].stem
+            for j, frame in enumerate(morph_pair(
+                aligned_images[i], aligned_images[i + 1],
+                full_landmarks[i], full_landmarks[i + 1],
+                triangles, frames_per_pair, include_endpoint,
+            )):
+                if overlay:
+                    t = j / frames_per_pair
+                    frame = draw_overlay(frame, label_b if t >= 0.5 else label_a)
+                yield frame
+            if on_progress:
+                on_progress("morph", i + 1, n_pairs)
+
+    encoder_name, encoder_args = pick_encoder(encoder)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    encode_video(all_frames(), output_path, canvas_w, canvas_h, fps, encoder_args)
+
+    total_frames = n_pairs * frames_per_pair + 1
+    if on_progress:
+        on_progress("done", 1, 1)
+
+    return RenderResult(
+        output_path=output_path,
+        canvas_w=canvas_w, canvas_h=canvas_h,
+        fps=fps, total_frames=total_frames,
+        used_files=used_files, skipped_files=skipped,
+        encoder=encoder_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _cli_progress() -> ProgressCallback:
+    """Translate on_progress events into tqdm bars + headers."""
+    bars: dict[str, tqdm] = {}
+    seen_stages: set[str] = set()
+
+    headers = {
+        "detect":      "[1/3] detecting landmarks",
+        "triangulate": "[2/3] computing template + Delaunay triangulation",
+        "morph":       "[3/3] morphing + encoding",
+    }
+
+    def cb(stage: str, current: int, total: int) -> None:
+        if stage in headers and stage not in seen_stages:
+            print(headers[stage])
+            seen_stages.add(stage)
+        if stage == "triangulate" or stage == "done":
+            return
+        if stage not in bars:
+            bars[stage] = tqdm(total=total, desc=stage, leave=True)
+        bars[stage].n = current
+        bars[stage].refresh()
+        if current == total:
+            bars[stage].close()
+
+    return cb
 
 
 def main() -> int:
@@ -308,117 +571,37 @@ def main() -> int:
                     help="Disable the filename caption burned into each frame.")
     ap.add_argument("--keep-aligned", action="store_true",
                     help="Also dump aligned still frames into --output.")
+    ap.add_argument("--encoder", default=None,
+                    help="Force a specific ffmpeg encoder (e.g. libx264, h264_nvenc). "
+                         "Default: auto-detect, prefer hardware.")
     args = ap.parse_args()
 
-    files = sorted(
-        p for p in args.input.iterdir()
-        if p.suffix.lower() in {".jpg", ".jpeg", ".png"}
-    )
-    if len(files) < 2:
-        print(f"need at least 2 images in {args.input}", file=sys.stderr)
-        return 1
-
-    # Determine canvas dimensions — explicit flags win, else first valid image.
-    if args.width and args.height:
-        canvas_w, canvas_h = args.width, args.height
-    else:
-        probe = None
-        for f in files:
-            probe = cv2.imread(str(f))
-            if probe is not None:
-                break
-        if probe is None:
-            print(f"could not read any image in {args.input}", file=sys.stderr)
-            return 1
-        h0, w0 = probe.shape[:2]
-        canvas_w = args.width or int(round(w0 * args.scale))
-        canvas_h = args.height or int(round(h0 * args.scale))
-
-    print(f"[1/4] detecting landmarks in {len(files)} images "
-          f"(canvas {canvas_w}x{canvas_h})")
-    template = canonical_template(canvas_w, canvas_h)
-    aligned_images: list[np.ndarray] = []
-    aligned_landmarks: list[np.ndarray] = []
-    used_files: list[Path] = []
-    skipped: list[Path] = []
-
-    landmarker = make_landmarker()
     try:
-        for f in tqdm(files):
-            img = cv2.imread(str(f))
-            if img is None:
-                skipped.append(f)
-                continue
-            lm = detect_landmarks(img, landmarker)
-            if lm is None:
-                skipped.append(f)
-                continue
-            try:
-                aligned_img, aligned_lm = align_to_canvas(
-                    img, lm, template, canvas_w, canvas_h,
-                )
-            except RuntimeError:
-                skipped.append(f)
-                continue
-            aligned_images.append(aligned_img)
-            aligned_landmarks.append(aligned_lm)
-            used_files.append(f)
-    finally:
-        landmarker.close()
-
-    if skipped:
-        print(f"  skipped {len(skipped)} (no face / unreadable):")
-        for p in skipped[:10]:
-            print(f"    - {p.name}")
-        if len(skipped) > 10:
-            print(f"    ... and {len(skipped) - 10} more")
-
-    if len(aligned_images) < 2:
-        print("not enough usable images after alignment", file=sys.stderr)
+        result = run_pipeline(
+            args.input, args.video,
+            width=args.width, height=args.height, scale=args.scale,
+            frames_per_pair=args.frames_per_pair, fps=args.fps,
+            overlay=not args.no_overlay,
+            keep_aligned_dir=args.output if args.keep_aligned else None,
+            encoder=args.encoder,
+            on_progress=_cli_progress(),
+        )
+    except (ValueError, RuntimeError) as e:
+        print(f"error: {e}", file=sys.stderr)
         return 1
 
-    if args.keep_aligned:
-        args.output.mkdir(parents=True, exist_ok=True)
-        for f, img in zip(used_files, aligned_images, strict=True):
-            cv2.imwrite(str(args.output / f"c_{f.name}"), img)
+    if result.skipped_files:
+        print(f"  skipped {len(result.skipped_files)} (no face / unreadable):")
+        for p in result.skipped_files[:10]:
+            print(f"    - {p.name}")
+        if len(result.skipped_files) > 10:
+            print(f"    ... and {len(result.skipped_files) - 10} more")
 
-    print("[2/4] computing template + Delaunay triangulation")
-    bnd = boundary_points(canvas_w, canvas_h)
-    full_landmarks = [np.vstack([lm, bnd]) for lm in aligned_landmarks]
-    mean_pts = np.mean(np.stack(full_landmarks), axis=0)
-    triangles = delaunay_triangles(mean_pts, canvas_w, canvas_h)
-    print(f"  {len(triangles)} triangles over {len(mean_pts)} vertices")
-
-    n_pairs = len(aligned_images) - 1
-    print(f"[3/4] morphing {n_pairs} pairs × {args.frames_per_pair} frames each")
-
-    def all_frames() -> Iterable[np.ndarray]:
-        pbar = tqdm(total=n_pairs)
-        for i in range(n_pairs):
-            include_endpoint = (i == n_pairs - 1)
-            label_a = used_files[i].stem
-            label_b = used_files[i + 1].stem
-            for j, frame in enumerate(morph_pair(
-                aligned_images[i], aligned_images[i + 1],
-                full_landmarks[i], full_landmarks[i + 1],
-                triangles, args.frames_per_pair, include_endpoint,
-            )):
-                if not args.no_overlay:
-                    # Show A's label until t crosses 0.5, then B's. With
-                    # frames_per_pair=N, t = j/N (or j/(N-1) on last pair).
-                    t = j / args.frames_per_pair
-                    frame = draw_overlay(frame, label_b if t >= 0.5 else label_a)
-                yield frame
-            pbar.update(1)
-        pbar.close()
-
-    print(f"[4/4] encoding to {args.video}")
-    args.video.parent.mkdir(parents=True, exist_ok=True)
-    encode_video(all_frames(), args.video, canvas_w, canvas_h, args.fps)
-
-    total_frames = n_pairs * args.frames_per_pair + 1
-    print(f"done: {args.video} ({total_frames} frames @ {args.fps} fps "
-          f"= {total_frames / args.fps:.1f}s)")
+    print(
+        f"done: {result.output_path} "
+        f"({result.total_frames} frames @ {result.fps} fps "
+        f"= {result.duration_seconds:.1f}s) [{result.encoder}]"
+    )
     return 0
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ mediapipe>=0.10.18
 opencv-python>=4.10.0
 numpy>=1.26,<3
 tqdm>=4.66
+
+# Web UI (only loaded when running `face-movie web`).
+fastapi>=0.115
+uvicorn[standard]>=0.32
+python-multipart>=0.0.18

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Mode dispatch:
+#   face-movie [args...]      → CLI (default)
+#   face-movie web [args...]  → Web UI on 0.0.0.0:8080
+
+if [[ "${1:-}" == "web" ]]; then
+    shift
+    echo "++++++++++++++ Face-Movie: web UI on http://0.0.0.0:8080"
+    exec uvicorn webapp.server:app --host 0.0.0.0 --port 8080 "$@"
+fi
+
 echo "++++++++++++++ Face-Movie: align + morph"
 python main.py "$@"
 echo "++++++++++++++ done"

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -25,16 +25,20 @@ import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.datastructures import UploadFile
 
 # Allow running `uvicorn webapp.server:app` from the repo root.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from main import run_pipeline  # noqa: E402
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
-MAX_FILES = 5000  # sanity cap on a single upload
+# Sanity cap. Picked above any realistic "selfie a day for 25 years" upload.
+# python-multipart's default of 1000 is too low; we override it explicitly
+# when parsing the form below.
+MAX_FILES = 25_000
 
 app = FastAPI(title="Face-Movie")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
@@ -66,17 +70,32 @@ async def index() -> HTMLResponse:
 
 
 @app.post("/api/render")
-async def start_render(
-    files: list[UploadFile] = File(...),
-    scale: float = Form(1.0),
-    frames_per_pair: int = Form(6),
-    fps: int = Form(30),
-    overlay: bool = Form(True),
-):
+async def start_render(request: Request):
+    # We parse the form ourselves so we can raise the multipart parser's
+    # max_files / max_fields limits beyond python-multipart's 1000 default.
+    # FastAPI's File()/Form() dependencies don't expose those knobs.
+    try:
+        form = await request.form(
+            max_files=MAX_FILES + 1,
+            max_fields=MAX_FILES + 32,
+        )
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(400, f"could not parse upload: {e}") from e
+
+    files = [f for f in form.getlist("files") if isinstance(f, UploadFile)]
     if len(files) < 2:
         raise HTTPException(400, "need at least 2 images")
     if len(files) > MAX_FILES:
         raise HTTPException(413, f"too many files (>{MAX_FILES})")
+
+    try:
+        scale = float(form.get("scale", "1.0"))
+        frames_per_pair = int(form.get("frames_per_pair", "6"))
+        fps = int(form.get("fps", "30"))
+        overlay = str(form.get("overlay", "true")).lower() in ("true", "1", "yes", "on")
+    except (TypeError, ValueError) as e:
+        raise HTTPException(400, f"invalid parameter: {e}") from e
+
     if not (0.1 <= scale <= 1.0):
         raise HTTPException(400, "scale must be between 0.1 and 1.0")
     if not (1 <= frames_per_pair <= 60):

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -1,0 +1,216 @@
+"""FastAPI server for face-movie.
+
+Single-tenant by design: in-memory job state, no auth, jobs survive only
+as long as the process. Wraps run_pipeline() from main.py so the CLI and
+the web UI share one code path. Intended to be run locally inside the
+Docker container; do not expose publicly without adding auth + a queue.
+
+Routes:
+    GET  /                      static SPA (index.html)
+    POST /api/render            multipart upload + params, starts a job
+    GET  /api/events/{job_id}   server-sent events stream of progress
+    GET  /api/download/{job_id} the rendered MP4
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import shutil
+import sys
+import tempfile
+import threading
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+# Allow running `uvicorn webapp.server:app` from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from main import run_pipeline  # noqa: E402
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+MAX_FILES = 5000  # sanity cap on a single upload
+
+app = FastAPI(title="Face-Movie")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@dataclass
+class Job:
+    id: str
+    work_dir: Path
+    input_dir: Path
+    output_path: Path
+    stage: str = "queued"
+    current: int = 0
+    total: int = 0
+    error: str | None = None
+    encoder: str | None = None
+    skipped: int = 0
+    used: int = 0
+    duration_s: float = 0.0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+JOBS: dict[str, Job] = {}
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    return HTMLResponse((STATIC_DIR / "index.html").read_text(encoding="utf-8"))
+
+
+@app.post("/api/render")
+async def start_render(
+    files: list[UploadFile] = File(...),
+    scale: float = Form(1.0),
+    frames_per_pair: int = Form(6),
+    fps: int = Form(30),
+    overlay: bool = Form(True),
+):
+    if len(files) < 2:
+        raise HTTPException(400, "need at least 2 images")
+    if len(files) > MAX_FILES:
+        raise HTTPException(413, f"too many files (>{MAX_FILES})")
+    if not (0.1 <= scale <= 1.0):
+        raise HTTPException(400, "scale must be between 0.1 and 1.0")
+    if not (1 <= frames_per_pair <= 60):
+        raise HTTPException(400, "frames_per_pair must be between 1 and 60")
+    if not (10 <= fps <= 60):
+        raise HTTPException(400, "fps must be between 10 and 60")
+
+    job_id = secrets.token_hex(8)
+    work_dir = Path(tempfile.mkdtemp(prefix=f"fm-{job_id}-"))
+    input_dir = work_dir / "input"
+    input_dir.mkdir()
+    output_path = work_dir / "out.mp4"
+
+    saved = 0
+    for upload in files:
+        # webkitdirectory uploads carry the relative path in `filename`.
+        # Flatten to basename and dedupe to avoid collisions.
+        raw = upload.filename or "img.jpg"
+        ext = Path(raw).suffix.lower()
+        if ext not in {".jpg", ".jpeg", ".png"}:
+            continue
+        stem = Path(raw).stem or "img"
+        target = input_dir / f"{stem}{ext}"
+        i = 0
+        while target.exists():
+            i += 1
+            target = input_dir / f"{stem}-{i}{ext}"
+        target.write_bytes(await upload.read())
+        saved += 1
+
+    if saved < 2:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise HTTPException(400, f"need at least 2 image files; got {saved} valid")
+
+    job = Job(id=job_id, work_dir=work_dir, input_dir=input_dir, output_path=output_path)
+    JOBS[job_id] = job
+
+    asyncio.get_running_loop().run_in_executor(
+        None,
+        _run_job_blocking,
+        job, scale, frames_per_pair, fps, overlay,
+    )
+    return {"job_id": job_id, "files": saved}
+
+
+def _run_job_blocking(
+    job: Job, scale: float, frames_per_pair: int, fps: int, overlay: bool,
+) -> None:
+    """Runs run_pipeline() on a worker thread. Mutates job under its lock."""
+    def progress(stage: str, current: int, total: int) -> None:
+        with job.lock:
+            job.stage = stage
+            job.current = current
+            job.total = total
+
+    try:
+        with job.lock:
+            job.stage = "starting"
+        result = run_pipeline(
+            input_dir=job.input_dir,
+            output_path=job.output_path,
+            scale=scale,
+            frames_per_pair=frames_per_pair,
+            fps=fps,
+            overlay=overlay,
+            on_progress=progress,
+        )
+        with job.lock:
+            job.stage = "done"
+            job.encoder = result.encoder
+            job.used = len(result.used_files)
+            job.skipped = len(result.skipped_files)
+            job.duration_s = result.duration_seconds
+    except Exception as e:  # noqa: BLE001
+        traceback.print_exc()
+        with job.lock:
+            job.stage = "error"
+            job.error = str(e) or e.__class__.__name__
+
+
+@app.get("/api/events/{job_id}")
+async def events(job_id: str):
+    if job_id not in JOBS:
+        raise HTTPException(404, "no such job")
+
+    job = JOBS[job_id]
+
+    async def stream():
+        last: tuple | None = None
+        while True:
+            with job.lock:
+                snap = (job.stage, job.current, job.total, job.error, job.encoder,
+                        job.used, job.skipped, job.duration_s)
+            if snap != last:
+                payload = {
+                    "stage": snap[0],
+                    "current": snap[1],
+                    "total": snap[2],
+                    "error": snap[3],
+                    "encoder": snap[4],
+                    "used": snap[5],
+                    "skipped": snap[6],
+                    "duration_s": snap[7],
+                }
+                yield f"data: {json.dumps(payload)}\n\n"
+                last = snap
+            if snap[0] in ("done", "error"):
+                return
+            await asyncio.sleep(0.4)
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@app.get("/api/download/{job_id}")
+async def download(job_id: str):
+    if job_id not in JOBS:
+        raise HTTPException(404)
+    job = JOBS[job_id]
+    if job.stage != "done":
+        raise HTTPException(409, "not ready")
+    return FileResponse(
+        job.output_path, media_type="video/mp4", filename="face-movie.mp4",
+    )
+
+
+@app.delete("/api/job/{job_id}")
+async def delete_job(job_id: str):
+    """Caller cleans up after themselves once they have the file."""
+    job = JOBS.pop(job_id, None)
+    if job is None:
+        raise HTTPException(404)
+    shutil.rmtree(job.work_dir, ignore_errors=True)
+    return {"ok": True}

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Face-Movie</title>
+<style>
+  :root {
+    --bg: #0f172a;
+    --bg-2: #1e293b;
+    --fg: #f8fafc;
+    --muted: #94a3b8;
+    --line: #334155;
+    --accent: #fb923c;
+    --accent-fg: #0f172a;
+    --error: #f87171;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px 80px;
+  }
+  .wrap { width: 100%; max-width: 640px; }
+  header { text-align: center; margin-bottom: 32px; }
+  h1 { margin: 0 0 8px; font-size: 32px; font-weight: 800; letter-spacing: -0.02em; }
+  .tagline { color: var(--muted); margin: 0; font-size: 15px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  .dropzone {
+    border: 2px dashed var(--line);
+    border-radius: 12px;
+    padding: 56px 20px;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    background: var(--bg-2);
+  }
+  .dropzone.dragover, .dropzone:hover {
+    border-color: var(--accent);
+    background: rgba(251, 146, 60, 0.05);
+  }
+  .dropzone strong { font-size: 16px; }
+  .dropzone .small {
+    color: var(--muted);
+    margin-top: 8px;
+    font-size: 13px;
+  }
+  .dropzone .picked {
+    color: var(--accent);
+    margin-top: 12px;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .controls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px 18px;
+    margin: 24px 0;
+  }
+  .control { display: flex; flex-direction: column; gap: 4px; }
+  .control label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .control input[type=number] {
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    background: var(--bg);
+    color: var(--fg);
+    border-radius: 8px;
+    font-size: 14px;
+    font-family: inherit;
+  }
+  .control input[type=number]:focus { outline: 2px solid var(--accent); outline-offset: -2px; border-color: var(--accent); }
+  .control.checkbox { flex-direction: row; align-items: center; gap: 8px; grid-column: 1 / -1; }
+  .control.checkbox input { width: 18px; height: 18px; accent-color: var(--accent); }
+  .control.checkbox label { text-transform: none; letter-spacing: normal; color: var(--fg); font-size: 14px; }
+
+  button.primary {
+    width: 100%;
+    padding: 14px 24px;
+    background: var(--accent);
+    color: var(--accent-fg);
+    border: none;
+    border-radius: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: opacity 0.15s, transform 0.05s;
+  }
+  button.primary:hover:not(:disabled) { opacity: 0.92; }
+  button.primary:active:not(:disabled) { transform: translateY(1px); }
+  button.primary:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .progress { margin-top: 24px; padding: 16px; background: var(--bg-2); border-radius: 10px; }
+  .progress .row { margin-bottom: 12px; }
+  .progress .row:last-child { margin-bottom: 0; }
+  .progress .label { font-size: 13px; color: var(--muted); margin-bottom: 4px; display: flex; justify-content: space-between; }
+  .progress .label .count { color: var(--fg); font-variant-numeric: tabular-nums; }
+  .bar { height: 6px; background: var(--bg); border-radius: 3px; overflow: hidden; }
+  .bar .fill { height: 100%; background: var(--accent); transition: width 0.2s; width: 0%; }
+
+  .result { margin-top: 24px; padding: 16px; background: var(--bg-2); border-radius: 10px; }
+  .result video { width: 100%; border-radius: 6px; display: block; }
+  .result .meta { color: var(--muted); font-size: 13px; margin: 12px 0 0; display: flex; justify-content: space-between; align-items: center; }
+  .result .download {
+    display: inline-block;
+    padding: 8px 16px;
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+  }
+  .result .download:hover { text-decoration: none; opacity: 0.92; }
+
+  .error { color: var(--error); font-size: 14px; margin-top: 16px; padding: 12px; background: rgba(248, 113, 113, 0.1); border-radius: 8px; border: 1px solid rgba(248, 113, 113, 0.3); }
+
+  footer { color: var(--muted); font-size: 12px; margin-top: 48px; text-align: center; }
+
+  [hidden] { display: none !important; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Face-Movie</h1>
+    <p class="tagline">Drop your selfies. Watch yourself age in 30 seconds.</p>
+  </header>
+
+  <div class="dropzone" id="drop">
+    <div><strong>Drop photos or a folder here</strong></div>
+    <div class="small">
+      or
+      <a href="#" id="pickFiles">choose files</a>
+      ·
+      <a href="#" id="pickFolder">choose folder</a>
+    </div>
+    <div class="picked" id="pickedCount"></div>
+  </div>
+
+  <input type="file" id="filesInput" multiple accept="image/jpeg,image/png" hidden />
+  <input type="file" id="folderInput" webkitdirectory hidden />
+
+  <div class="controls">
+    <div class="control">
+      <label for="scale">Scale (0.1 – 1.0)</label>
+      <input type="number" id="scale" value="1.0" min="0.1" max="1.0" step="0.1" />
+    </div>
+    <div class="control">
+      <label for="fpp">Frames per transition</label>
+      <input type="number" id="fpp" value="6" min="1" max="60" step="1" />
+    </div>
+    <div class="control">
+      <label for="fps">Output FPS</label>
+      <input type="number" id="fps" value="30" min="10" max="60" step="1" />
+    </div>
+    <div class="control">
+      <!-- spacer to keep grid aligned -->
+    </div>
+    <div class="control checkbox">
+      <input type="checkbox" id="overlay" checked />
+      <label for="overlay">Burn the filename into each frame</label>
+    </div>
+  </div>
+
+  <button class="primary" id="render" disabled>Render</button>
+
+  <div class="progress" id="progress" hidden>
+    <div class="row">
+      <div class="label">
+        <span id="stageLabel">Starting…</span>
+        <span class="count" id="stageCount"></span>
+      </div>
+      <div class="bar"><div class="fill" id="fill"></div></div>
+    </div>
+  </div>
+
+  <div class="error" id="errorBox" hidden></div>
+
+  <div class="result" id="result" hidden>
+    <video id="video" controls autoplay loop></video>
+    <div class="meta">
+      <span id="resultMeta"></span>
+      <a id="downloadLink" class="download" download="face-movie.mp4">Download MP4</a>
+    </div>
+  </div>
+
+  <footer>
+    Local Docker container. Photos never leave your machine.
+    See <a href="https://github.com/leachiM2k/face-movie">github.com/leachiM2k/face-movie</a> for the CLI.
+  </footer>
+</div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const drop = $("drop");
+const filesInput = $("filesInput");
+const folderInput = $("folderInput");
+const renderBtn = $("render");
+const pickedCount = $("pickedCount");
+const progress = $("progress");
+const stageLabel = $("stageLabel");
+const stageCount = $("stageCount");
+const fill = $("fill");
+const errorBox = $("errorBox");
+const result = $("result");
+const video = $("video");
+const downloadLink = $("downloadLink");
+const resultMeta = $("resultMeta");
+
+let selected = [];
+let activeJob = null;
+
+const IMG_RE = /\.(jpe?g|png)$/i;
+
+$("pickFiles").addEventListener("click", (e) => { e.preventDefault(); filesInput.click(); });
+$("pickFolder").addEventListener("click", (e) => { e.preventDefault(); folderInput.click(); });
+filesInput.addEventListener("change", () => setFiles([...filesInput.files]));
+folderInput.addEventListener("change", () => setFiles([...folderInput.files]));
+
+drop.addEventListener("click", (e) => {
+  // Click anywhere in the dropzone (except the inner links) opens the file picker.
+  if (e.target.tagName !== "A") filesInput.click();
+});
+drop.addEventListener("dragover", (e) => { e.preventDefault(); drop.classList.add("dragover"); });
+drop.addEventListener("dragleave", () => drop.classList.remove("dragover"));
+drop.addEventListener("drop", async (e) => {
+  e.preventDefault();
+  drop.classList.remove("dragover");
+  const items = [...e.dataTransfer.items];
+  const collected = [];
+  await Promise.all(items.map(async (item) => {
+    if (item.kind !== "file") return;
+    const entry = item.webkitGetAsEntry?.();
+    if (entry?.isDirectory) {
+      await traverseDir(entry, collected);
+    } else {
+      const f = item.getAsFile();
+      if (f) collected.push(f);
+    }
+  }));
+  setFiles(collected);
+});
+
+async function traverseDir(dirEntry, out) {
+  const reader = dirEntry.createReader();
+  const readBatch = () => new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+  while (true) {
+    const entries = await readBatch();
+    if (!entries.length) return;
+    for (const e of entries) {
+      if (e.isFile) {
+        await new Promise((resolve) => e.file((f) => { out.push(f); resolve(); }));
+      } else if (e.isDirectory) {
+        await traverseDir(e, out);
+      }
+    }
+  }
+}
+
+function setFiles(arr) {
+  selected = arr.filter((f) => IMG_RE.test(f.name));
+  if (!selected.length) {
+    pickedCount.textContent = "no images selected";
+    renderBtn.disabled = true;
+    return;
+  }
+  pickedCount.textContent = `${selected.length} image${selected.length === 1 ? "" : "s"} selected`;
+  renderBtn.disabled = selected.length < 2;
+}
+
+renderBtn.addEventListener("click", async () => {
+  errorBox.hidden = true;
+  result.hidden = true;
+  progress.hidden = false;
+  renderBtn.disabled = true;
+
+  fill.style.width = "0%";
+  stageLabel.textContent = "Uploading…";
+  stageCount.textContent = "";
+
+  const fd = new FormData();
+  selected.forEach((f) => fd.append("files", f, f.name));
+  fd.append("scale", $("scale").value);
+  fd.append("frames_per_pair", $("fpp").value);
+  fd.append("fps", $("fps").value);
+  fd.append("overlay", $("overlay").checked ? "true" : "false");
+
+  let job_id;
+  try {
+    const r = await fetch("/api/render", { method: "POST", body: fd });
+    if (!r.ok) {
+      const text = await r.text().catch(() => r.statusText);
+      throw new Error(text || `HTTP ${r.status}`);
+    }
+    ({ job_id } = await r.json());
+  } catch (err) {
+    showError(err.message);
+    progress.hidden = true;
+    renderBtn.disabled = false;
+    return;
+  }
+
+  activeJob = job_id;
+  followJob(job_id);
+});
+
+function followJob(jobId) {
+  const es = new EventSource(`/api/events/${jobId}`);
+  es.onmessage = (ev) => {
+    const d = JSON.parse(ev.data);
+    if (d.error) {
+      showError(d.error);
+      es.close();
+      progress.hidden = true;
+      renderBtn.disabled = false;
+      cleanupJob(jobId);
+      return;
+    }
+    updateStage(d);
+    if (d.stage === "done") {
+      es.close();
+      showResult(jobId, d);
+      renderBtn.disabled = false;
+    }
+  };
+  es.onerror = () => {
+    es.close();
+    showError("connection to server lost");
+    renderBtn.disabled = false;
+  };
+}
+
+function updateStage(d) {
+  const labels = {
+    starting: "Starting…",
+    detect: "Detecting faces",
+    triangulate: "Triangulating",
+    morph: "Morphing & encoding",
+  };
+  stageLabel.textContent = labels[d.stage] || d.stage;
+  if (d.total > 0) {
+    stageCount.textContent = `${d.current} / ${d.total}`;
+    fill.style.width = `${(d.current / d.total) * 100}%`;
+  } else {
+    stageCount.textContent = "";
+  }
+}
+
+function showResult(jobId, d) {
+  progress.hidden = true;
+  const url = `/api/download/${jobId}`;
+  video.src = url + `?t=${Date.now()}`;
+  downloadLink.href = url;
+  const parts = [`${d.duration_s.toFixed(1)} s`];
+  if (d.encoder) parts.push(d.encoder);
+  parts.push(`${d.used} photos`);
+  if (d.skipped) parts.push(`${d.skipped} skipped`);
+  resultMeta.textContent = parts.join(" · ");
+  result.hidden = false;
+}
+
+function showError(msg) {
+  errorBox.textContent = msg;
+  errorBox.hidden = false;
+}
+
+function cleanupJob(jobId) {
+  // best-effort cleanup; ignore failure
+  fetch(`/api/job/${jobId}`, { method: "DELETE" }).catch(() => {});
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a local-first web UI alongside the existing CLI, plus opportunistic
GPU acceleration for landmark detection and video encoding. Single-tenant,
runs inside the existing Docker image, photos never leave the user's
machine.

## Two commits

### 1 · `41d4b0b` Pipeline refactor + HW encoder + GPU delegate

The inline pipeline in `main()` is split into:

```python
run_pipeline(input_dir, output_path, *, on_progress=cb, ...) -> RenderResult
```

The CLI's `main()` is a thin wrapper that turns the callback into tqdm
bars. The web UI uses the same callback to push SSE progress events.

- **HW video encoder (Layer 1):** `pick_encoder()` scans `ffmpeg -encoders`
  and picks `h264_videotoolbox` (macOS), `h264_nvenc` (NVIDIA), `h264_qsv`
  (Intel), `h264_amf` (AMD), `h264_v4l2m2m` (Pi), or falls back to
  `libx264`. New `--encoder NAME` flag overrides.
- **MediaPipe GPU delegate (Layer 2):** tries Metal/OpenGL ES first,
  falls back to CPU on init failure. Detection input switched to RGBA
  (was RGB) so the macOS Metal path stops aborting inside libabsl on the
  ImageFrame conversion. `FACE_MOVIE_DELEGATE=cpu` forces the CPU path
  for systems where GPU silently SIGABRTs on first detect.

### 2 · `823f11d` FastAPI + vanilla HTML drop-zone

```
webapp/
  server.py           ~170 LoC, single-tenant, in-memory jobs
  static/index.html   ~280 LoC, drag-drop, folder picker, SSE progress
```

Endpoints:

| Method | Path | What |
|---|---|---|
| GET | `/` | the SPA |
| POST | `/api/render` | multipart upload + params, starts a job |
| GET | `/api/events/{id}` | server-sent events progress stream |
| GET | `/api/download/{id}` | rendered MP4 |
| DELETE | `/api/job/{id}` | cleanup tmp dir |

Photo upload accepts:

- drag and drop of files **or a directory** (recurses subfolders via
  `webkitGetAsEntry`)
- "choose files" picker
- "choose folder" picker (`webkitdirectory`)

`Dockerfile` copies `webapp/`, exposes `8080`, `start.sh` dispatches:

```bash
docker run --rm leachim2k/face-movie                    # CLI (unchanged)
docker run --rm -p 8080:8080 leachim2k/face-movie web   # Web UI
```

`requirements.txt` adds `fastapi`, `uvicorn[standard]`, `python-multipart`
(~5–8 MB image growth).

## Tested locally

- CLI: 3 sample photos → 0.3 s MP4, 768×512, `[h264_videotoolbox]` (M3 Max)
- Web: `uvicorn webapp.server:app` → curl POST 3 samples → SSE done event
  → download returns valid 320 KB MP4
- MediaPipe GPU delegate active (Metal on M3); CPU fallback path tested
  via `FACE_MOVIE_DELEGATE=cpu`

## Tradeoffs / things explicitly out of scope for v1

- Single-job concurrency (no queue). Add a `Semaphore`/Redis if you
  ever expose this publicly.
- In-memory job state. Container restart loses pending jobs.
- No auth. Bind to `127.0.0.1` (Python launch) or keep behind firewall
  (Docker case `-p 127.0.0.1:8080:8080`) if you want extra paranoia.
- No live-preview of in-progress morphing (stretch goal for v2).
- No CUDA OpenCV (`cv2.cuda.warpAffine` would 5× the morph step but
  needs a separate CUDA-only image variant — deferred until requested).

## Test plan after merge

- [ ] `docker pull leachim2k/face-movie:latest` resolves to manifest list
      with `linux/amd64` + `linux/arm64`
- [ ] `docker run --rm leachim2k/face-movie` (no args) runs CLI as before
- [ ] `docker run --rm -p 8080:8080 leachim2k/face-movie web` exposes
      a working UI on http://localhost:8080
